### PR TITLE
Create Example TCP Server to Validate JSON Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # dhcp-hive-mind
 Track DHCP leases in Redis.
+
+An example client/server exchange might look like this:
+```
+DHCPDISCOVER client ------> {'mac': 'aa:bb:cc:dd:ee:ff',
+                             'hostname': 'foobar',
+                             'router': '10.0.0.1'} -----------------> broadcast
+# I have no layer 3 and what is this?
+
+DHCPOFFER    client <------ {'ip': '10.0.0.2'} <------------------------ server
+# Hey, use this IP.
+
+DHCPREQUEST  client ------> {'ip': '10.0.0.2'} ------------------------> server
+# Hey, I want to use this IP.
+
+DHCPACK      client <------ {'lease end': 'some datetime'} <------------ server
+# K.
+```

--- a/bin/dhcphm
+++ b/bin/dhcphm
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+var DHCPHiveMind = require('../')();
+DHCPHiveMind.serve();

--- a/bin/dhcphm
+++ b/bin/dhcphm
@@ -1,3 +1,4 @@
 #!/usr/bin/env node
-var DHCPHiveMind = require('../')();
+var opts = {}
+var DHCPHiveMind = require('../')(opts);
 DHCPHiveMind.serve();

--- a/index.js
+++ b/index.js
@@ -1,6 +1,2 @@
 'use strict';
-module.exports = function DHCPHiveMind(opts) {
-  opts = opts || {};
-
-  return opts;
-}
+module.exports = require('./lib/dhcp-hive-mind');

--- a/lib/dhcp-hive-mind.js
+++ b/lib/dhcp-hive-mind.js
@@ -1,0 +1,66 @@
+'use strict';
+
+// Require the networking and redis modules.
+var net = require('net');
+var path = require('path');
+var redis = require('redis');
+
+
+function DHCPHiveMind(opts) {
+
+  // Make the current scope of this available as self.
+  var self = this;
+
+  // Make function parameters optional.
+  opts = opts || {};
+  this.name = opts.name || path.basename(process.argv[1]);
+  this.host = opts.host || 'localhost';
+  this.port = opts.port || 1067;
+
+  this.validateRequest = function(data) {
+    try {
+      var validJSON = JSON.parse(data);
+      return validJSON;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  this.serve = function() {
+
+    // Instantiate a net.Server class.
+    var server = net.createServer(function(conn) {
+
+      // Log client connections.
+      console.log(self.name + ': client connected');
+
+      // Log client disconnections.
+      conn.on('end', function() {
+        console.log(self.name + ': client disconnected');
+      });
+
+      // Handle data from connected clients.
+      conn.on('data', function(data) {
+        // Validate incoming data as JSON.
+        var req = self.validateRequest(data.toString());
+        if (req) {
+          console.log(self.name + ': ' + req);
+          // If it's JSON parse the request.
+          // Update Redis DB accordingly.
+        } else {
+          console.log(self.name + ': error: invalid request');
+        }
+      });
+    });
+
+    // Listen on the default interface and port.
+    server.listen(self.port, self.host, function() {
+      console.log(self.name + ': server bound on ' + self.host + ':' + self.port);
+    });
+  }
+}
+
+// Export a DHCPHiveMind factory.
+module.exports = function createDHCPHiveMind(opts) {
+  return new DHCPHiveMind(opts);
+}

--- a/lib/dhcp-hive-mind.js
+++ b/lib/dhcp-hive-mind.js
@@ -16,11 +16,28 @@ function DHCPHiveMind(opts) {
   this.name = opts.name || path.basename(process.argv[1]);
   this.host = opts.host || 'localhost';
   this.port = opts.port || 1067;
+  this.discoverKeys = opts.discoverKeys || ['hostname', 'mac', 'router'];
+  this.requestKeys = opts.requestKeys || ['ip'];
 
   this.validateRequest = function(data) {
+
+    // Try to parse the data as JSON.
     try {
-      var validJSON = JSON.parse(data);
-      return validJSON;
+      var req = JSON.parse(data);
+
+      // Verify the request has valid keys and possibly set the request type.
+      var reqKeys = JSON.stringify(Object.keys(req).sort());
+      if (reqKeys === JSON.stringify(self.discoverKeys.sort())) {
+        req.type = 'DHCPDISCOVER';
+      } else if (reqKeys === JSON.stringify(self.requestKeys.sort())) {
+        req.type = 'DHCPREQUEST';
+      } else {
+        return false;
+      }
+
+      // Everything's OK! Return the request object.
+      return req;
+
     } catch (err) {
       return false;
     }
@@ -31,31 +48,37 @@ function DHCPHiveMind(opts) {
     // Instantiate a net.Server class.
     var server = net.createServer(function(conn) {
 
+      // Store the remote address of the client.
+      var remote = conn.remoteAddress + ':' + conn.remotePort;
+
       // Log client connections.
-      console.log(self.name + ': client connected');
+      console.log(self.name + ': info: ' + remote + ' connected');
 
       // Log client disconnections.
       conn.on('end', function() {
-        console.log(self.name + ': client disconnected');
+        console.log(self.name + ': info: ' + remote + ' disconnected');
       });
 
       // Handle data from connected clients.
       conn.on('data', function(data) {
+
         // Validate incoming data as JSON.
         var req = self.validateRequest(data.toString());
+
+        // If the request is valid, process it.
         if (req) {
-          console.log(self.name + ': ' + req);
-          // If it's JSON parse the request.
-          // Update Redis DB accordingly.
+          console.log(self.name + ': info: ' + req.type + ' from ' + remote);
+          // UPDATE REDIS DB WITH REQUEST VALUES HERE.
+          // SEND RESPONSE TO CLIENT HERE.
         } else {
-          console.log(self.name + ': error: invalid request');
+          console.log(self.name + ': error: invalid request from ' + remote);
         }
       });
     });
 
     // Listen on the default interface and port.
     server.listen(self.port, self.host, function() {
-      console.log(self.name + ': server bound on ' + self.host + ':' + self.port);
+      console.log(self.name + ': info: server bound on ' + self.host + ':' + self.port);
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Track DHCP leases in Redis.",
   "main": "index.js",
   "scripts": {
+    "start": "node ./bin/dhcphm",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
I've done the scaffolding for an example which shows how a Node.js module might do validation of JSON requests over TCP. It won't really mirror what's happening in DHCP, but I think we can still use this to illustrate our point. We'll still need to take care of actually inserting requests into `redis` and responding appropriately to the client.

To test the application now you can do the following:

```
git clone https://github.com/reillysiemens/dhcp-hive-mind example
cd example
git checkout example
npm install
npm start
```

You should see output that looks like:

```
> dhcp-hive-mind@0.1.0 start /home/tucker/projects/wwu-nosql/example
> node ./bin/dhcphm

dhcphm: info: server bound on localhost:1067
```

Opening up `nc localhost 1067` and throwing a few lines of (in)appropriately formatted JSON might produce something like this:

```
dhcphm: info: server bound on localhost:1067
dhcphm: info: 127.0.0.1:55394 connected
dhcphm: info: DHCPREQUEST from 127.0.0.1:55394
dhcphm: info: 127.0.0.1:55394 disconnected
dhcphm: info: 127.0.0.1:55395 connected
dhcphm: info: DHCPDISCOVER from 127.0.0.1:55395
dhcphm: info: 127.0.0.1:55395 disconnected
dhcphm: info: 127.0.0.1:55396 connected
dhcphm: error: invalid request from 127.0.0.1:55396
dhcphm: info: 127.0.0.1:55396 disconnected
dhcphm: info: 127.0.0.1:55397 connected
dhcphm: error: invalid request from 127.0.0.1:55397
dhcphm: info: 127.0.0.1:55397 disconnected
dhcphm: info: 127.0.0.1:55398 connected
dhcphm: info: DHCPREQUEST from 127.0.0.1:55398
dhcphm: info: 127.0.0.1:55398 disconnected
dhcphm: info: 127.0.0.1:55399 connected
dhcphm: info: DHCPDISCOVER from 127.0.0.1:55399
dhcphm: info: 127.0.0.1:55399 disconnected
```

Use `^C` to kill the server.

Useful reading if we choose to move forward from here:
- [The Node.js `net` module API](https://nodejs.org/api/net.html)
- [The source for the `node_redis` library](https://github.com/mranney/node_redis)
