### PR TITLE
Send responses from server to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,44 @@ Track DHCP leases in Redis.
 
 An example client/server exchange might look like this:
 ```
-DHCPDISCOVER client ------> {'mac': 'aa:bb:cc:dd:ee:ff',
-                             'hostname': 'foobar',
-                             'router': '10.0.0.1'} -----------------> broadcast
-# I have no layer 3 and what is this?
+client -> broadcast
+{ 
+  "msg_type": "DHCPDISCOVER",       # option 53
+  "client_mac": "my mac address",   # CHADDR
+  "hostname": "foobar",             # option 12
+  "relay_ip": "ip-helper address"   # GIADDR? (Set by relay agent)
+}
 
-DHCPOFFER    client <------ {'ip': '10.0.0.2'} <------------------------ server
-# Hey, use this IP.
+server -> client
+{ 
+  "msg_type": "DHCPOFFER",                  # option 53
+  "client_ip": "proposed ip addr",          # YIADDR
+  "client_mac": "client's mac address",     # CHADDR
+  "server_ip": "my ip addr",                # SIADDR / option 54
+  "relay_ip": "ip-helper address"           # GIADDR? (Set by server)
+  "lease_time": "lease length in seconds",  # option 51
+  "subnet_mask": "255.255.maybe.whatever",  # option 1
+  "router": "router's ip addr",             # option 3
+}
 
-DHCPREQUEST  client ------> {'ip': '10.0.0.2'} ------------------------> server
-# Hey, I want to use this IP.
+client -> broadcast/server
+{ 
+  "msg_type": "DHCPREQUEST",        # option 53
+  "client_ip": "requested ip addr", # option 50
+  "client_mac": "my mac address",   # CHADDR
+  "hostname": "foobar",             # option 12
+  "relay_ip": "ip-helper address"   # GIADDR? (Set by relay agent)
+}
 
-DHCPACK      client <------ {'lease end': 'some datetime'} <------------ server
-# K.
+server -> client
+{ 
+  "msg_type": "DHCPACK",                    # option 53
+  "client_ip": "ack'ed ip addr",            # YIADDR
+  "client_mac": "client's mac address",     # CHADDR
+  "server_ip": "my ip addr",                # SIADDR / option 54
+  "relay_ip": "ip-helper address"           # GIADDR? (Set by server)
+  "lease_time": "lease length in seconds",  # option 51
+  "subnet_mask": "255.255.maybe.whatever",  # option 1
+  "router": "router's ip addr",             # option 3
+}
 ```

--- a/lib/dhcp-hive-mind.js
+++ b/lib/dhcp-hive-mind.js
@@ -16,8 +16,68 @@ function DHCPHiveMind(opts) {
   this.name = opts.name || path.basename(process.argv[1]);
   this.host = opts.host || 'localhost';
   this.port = opts.port || 1067;
-  this.discoverKeys = opts.discoverKeys || ['hostname', 'mac', 'router'];
-  this.requestKeys = opts.requestKeys || ['ip'];
+  this.discoverKeys = opts.discoverKeys || ['msg_type', 'client_mac', 'hostname', 'relay_ip'];
+  this.requestKeys = opts.requestKeys || ['msg_type', 'client_ip', 'client_mac', 'hostname', 'relay_ip'];
+
+  this.handleDiscover = function(conn, req) {
+
+    // Handle and respond to client's DHCPDISCOVER.
+    var clientIP = '240.0.0.2'; // fake
+    var serverIP = '67.201.248.10'; // also fake
+    var subnetMask = '255.255.255.128'; // also fake
+    var leaseTime = 86400; // seconds
+
+    var resp = { 
+      "msg_type": "DHCPOFFER",
+      "client_ip": clientIP,
+      "client_mac": req.client_mac,
+      "server_ip": serverIP,
+      "relay_ip": req.relay_ip,
+      "lease_time": leaseTime,
+      "subnet_mask": subnetMask,
+      "router": req.relay_ip
+    };
+
+    this.sendOffer(conn, resp);
+  }
+
+  this.sendOffer = function(conn, resp) {
+
+    // Send DHCPOFFER.
+    var msg = 'DHCPOFFER on ' + resp.client_ip + ' to ' + resp.client_mac;
+    conn.write(msg + '\r\n');
+    console.log(self.name + ': info: ' + msg);
+  }
+
+  this.handleRequest = function(conn, req) {
+
+    // Respond to client's DHCPREQUEST.
+    // Just ACK without validating (for now).
+    var serverIP = '67.201.248.10'; // fake
+    var subnetMask = '255.255.255.128'; // also fake
+    var leaseTime = 86400; // seconds
+
+    var resp = {
+      "msg_type": "DHCPACK",
+      "client_ip": req.client_ip,
+      "client_mac": req.client_mac,
+      "server_ip": serverIP,
+      "relay_ip": req.relay_ip,
+      "lease_time": leaseTime,
+      "subnet_mask": subnetMask,
+      "router": req.relay_ip
+    }
+
+    this.sendAck(conn, resp);
+  }
+
+  this.sendAck = function(conn, resp) {
+
+    // Send DHCPACK.
+    var msg = 'DHCPACK on ' + resp.client_ip + ' to ' + resp.client_mac + ' -- lease length ' + resp.lease_time + ' seconds';
+    conn.write(msg + '\r\n');
+    console.log(self.name + ': info: ' + msg);
+  }
 
   this.validateRequest = function(data) {
 
@@ -27,9 +87,9 @@ function DHCPHiveMind(opts) {
 
       // Verify the request has valid keys and possibly set the request type.
       var reqKeys = JSON.stringify(Object.keys(req).sort());
-      if (reqKeys === JSON.stringify(self.discoverKeys.sort())) {
-        req.type = 'DHCPDISCOVER';
-      } else if (reqKeys === JSON.stringify(self.requestKeys.sort())) {
+      if (reqKeys === JSON.stringify(self.discoverKeys.sort()) && req.msg_type === 'DHCPDISCOVER') {
+        req.type = 'DHCPDISCOVER'; // Not sure if explicitly setting this is needed anymore
+      } else if (reqKeys === JSON.stringify(self.requestKeys.sort()) && req.msg_type === 'DHCPREQUEST') {
         req.type = 'DHCPREQUEST';
       } else {
         return false;
@@ -69,7 +129,13 @@ function DHCPHiveMind(opts) {
         if (req) {
           console.log(self.name + ': info: ' + req.type + ' from ' + remote);
           // UPDATE REDIS DB WITH REQUEST VALUES HERE.
-          // SEND RESPONSE TO CLIENT HERE.
+
+          if (req.type === 'DHCPDISCOVER') {
+            self.handleDiscover(conn, req);
+          } else if (req.type === 'DHCPREQUEST') {
+            self.handleRequest(conn, req);
+          }
+
         } else {
           console.log(self.name + ': error: invalid request from ' + remote);
         }


### PR DESCRIPTION
Try:

```
{"msg_type": "DHCPDISCOVER", "client_mac": "aa:bb:cc:dd:ee:ff", "hostname": "foobar", "relay_ip": "240.0.0.1"}
{"msg_type": "DHCPREQUEST", "client_mac": "aa:bb:cc:dd:ee:ff", "hostname": "foobar", "relay_ip": "240.0.0.1", "client_ip": "240.0.0.2"}
```

Do not expect anything except the bare minimum (presence of message fields) to be validated.
